### PR TITLE
feat: 알림 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
@@ -38,8 +38,8 @@ public class CommentService {
         final Member member = getMemberOrThrow(getCurrentMemberId());
         final Comment comment = createComment(command, post, member);
         final Comment savedComment = commentRepository.save(comment);
-        notificationService.createNotification(post.getId(), post.getMember().getId(),
-                NotificationType.COMMENT_POSTED);
+        notificationService.createNotification(member.getId(), post.getMember().getId(),
+                post.getId(), NotificationType.COMMENT_POSTED);
         return savedComment;
     }
 

--- a/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
@@ -8,6 +8,8 @@ import com.example.favoriteschoolmeal.domain.comment.repository.CommentRepositor
 import com.example.favoriteschoolmeal.domain.comment.service.dto.CreateCommentCommand;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.member.service.MemberService;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.service.NotificationService;
 import com.example.favoriteschoolmeal.domain.post.domain.Post;
 import com.example.favoriteschoolmeal.domain.post.exception.PostException;
 import com.example.favoriteschoolmeal.domain.post.exception.PostExceptionType;
@@ -28,13 +30,17 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final MemberService memberService;
+    private final NotificationService notificationService;
 
     public Comment addComment(final CreateCommentCommand command) {
         verifyUserOrAdmin();
         final Post post = getPostOrThrow(command.postId());
         final Member member = getMemberOrThrow(getCurrentMemberId());
         final Comment comment = createComment(command, post, member);
-        return commentRepository.save(comment);
+        final Comment savedComment = commentRepository.save(comment);
+        notificationService.createNotification(post.getId(), post.getMember().getId(),
+                NotificationType.COMMENT_POSTED);
+        return savedComment;
     }
 
     public Comment modifyComment(final Long commentId, final CreateCommentCommand command) {

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/repository/MatchingMemberRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/repository/MatchingMemberRepository.java
@@ -37,4 +37,14 @@ public interface MatchingMemberRepository extends JpaRepository<MatchingMember, 
      * @return 해당 Matching에 연관된 MatchingMember 리스트
      */
     List<MatchingMember> findAllByMatching(Matching matching);
+
+    /**
+     * 특정 Matching에 대한 특정 MatchingRequestStatus를 가진 MatchingMember를 조회합니다.
+     *
+     * @param matching 조회할 Matching 엔티티
+     * @param status   조회할 MatchingRequestStatus
+     * @return 해당 Matching에 연관된 MatchingMember 리스트
+     */
+    List<MatchingMember> findByMatchingAndMatchingRequestStatus(Matching matching,
+            MatchingRequestStatus status);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
@@ -1,0 +1,20 @@
+package com.example.favoriteschoolmeal.domain.model;
+
+public enum NotificationType {
+    COMMENT_POSTED(1),
+    MATCHING_REQUESTED(2),
+    MATCHING_CANCELED(3),
+    MATCHING_ACCEPTED(4),
+    MATCHING_REJECTED(5),
+    MATCHING_COMPLETED(6);
+
+    private final int id;
+
+    NotificationType(final int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
@@ -1,0 +1,5 @@
+package com.example.favoriteschoolmeal.domain.notification.controller;
+
+public class NotificationController {
+
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
@@ -1,11 +1,14 @@
 package com.example.favoriteschoolmeal.domain.notification.controller;
 
 import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationListResponse;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationResponse;
 import com.example.favoriteschoolmeal.domain.notification.controller.dto.UnreadNotificationStatusResponse;
 import com.example.favoriteschoolmeal.domain.notification.service.NotificationService;
 import com.example.favoriteschoolmeal.global.common.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +34,14 @@ public class NotificationController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<UnreadNotificationStatusResponse> unreadNotificationsCheck() {
         final UnreadNotificationStatusResponse response = notificationService.hasUnreadNotifications();
+        return ApiResponse.createSuccess(response);
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<NotificationResponse> notificationRead(
+            @PathVariable final Long notificationId) {
+        final NotificationResponse response = notificationService.readNotification(notificationId);
         return ApiResponse.createSuccess(response);
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
@@ -1,5 +1,36 @@
 package com.example.favoriteschoolmeal.domain.notification.controller;
 
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationListResponse;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.UnreadNotificationStatusResponse;
+import com.example.favoriteschoolmeal.domain.notification.service.NotificationService;
+import com.example.favoriteschoolmeal.global.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
 public class NotificationController {
 
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping("")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<NotificationListResponse> notificationList() {
+        final NotificationListResponse response = notificationService.findAllNotification();
+        return ApiResponse.createSuccess(response);
+    }
+
+    @GetMapping("/unread-status")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<UnreadNotificationStatusResponse> unreadNotificationsCheck() {
+        final UnreadNotificationStatusResponse response = notificationService.hasUnreadNotifications();
+        return ApiResponse.createSuccess(response);
+    }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationListResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationListResponse.java
@@ -1,0 +1,13 @@
+package com.example.favoriteschoolmeal.domain.notification.controller.dto;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationResponse> notificationList) {
+
+    public static NotificationListResponse from(final List<NotificationResponse> notificationList) {
+        return new NotificationListResponse(
+                notificationList
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
@@ -5,7 +5,8 @@ import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
 public record NotificationResponse(
         Long notificationId,
         Long postId,
-        Long memberId,
+        Long receiverId,
+        Long senderId,
         Integer notificationType,
         String createdAt,
         Boolean isRead) {
@@ -14,7 +15,8 @@ public record NotificationResponse(
         return new NotificationResponse(
                 notification.getId(),
                 notification.getPostId(),
-                notification.getMember().getId(),
+                notification.getReceiver().getId(),
+                notification.getSenderId(),
                 notification.getNotificationType().getId(),
                 notification.getFormattedCreatedAt(),
                 notification.getIsRead()

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
@@ -1,0 +1,23 @@
+package com.example.favoriteschoolmeal.domain.notification.controller.dto;
+
+import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+
+public record NotificationResponse(
+        Long notificationId,
+        Long postId,
+        Long memberId,
+        Integer notificationType,
+        String createdAt,
+        Boolean isRead) {
+
+    public static NotificationResponse from(final Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getPostId(),
+                notification.getMember().getId(),
+                notification.getNotificationType().getId(),
+                notification.getFormattedCreatedAt(),
+                notification.getIsRead()
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/UnreadNotificationStatusResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/UnreadNotificationStatusResponse.java
@@ -1,0 +1,14 @@
+package com.example.favoriteschoolmeal.domain.notification.controller.dto;
+
+/**
+ * 안 읽은 알림의 존재 유무를 나타내는 응답 객체입니다.
+ */
+public record UnreadNotificationStatusResponse(
+        boolean hasUnread) {
+
+    public static UnreadNotificationStatusResponse from(final boolean hasUnread) {
+        return new UnreadNotificationStatusResponse(
+                hasUnread
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
@@ -1,7 +1,18 @@
 package com.example.favoriteschoolmeal.domain.notification.domain;
 
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
-import jakarta.persistence.*;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +22,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "notification")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-
 public class Notification {
 
     @Id
@@ -23,16 +33,22 @@ public class Notification {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "content", nullable = false, length = 300)
-    private String content;
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false)
+    private NotificationType notificationType;
 
     @Column(name = "is_read", nullable = false)
     private Boolean isRead;
 
     @Builder
-    public Notification(Member member, String content, Boolean isRead) {
+    public Notification(Member member, Long postId, NotificationType notificationType,
+            Boolean isRead) {
         this.member = member;
-        this.content = content;
+        this.postId = postId;
+        this.notificationType = notificationType;
         this.isRead = isRead;
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
@@ -52,4 +52,8 @@ public class Notification extends Base {
         this.notificationType = notificationType;
         this.isRead = isRead;
     }
+
+    public void readNotification() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
@@ -2,6 +2,7 @@ package com.example.favoriteschoolmeal.domain.notification.domain;
 
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.global.common.Base;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "notification")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends Base {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
@@ -19,40 +19,78 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 알림 정보를 저장하는 엔티티 클래스입니다.
+ */
 @Entity
 @Table(name = "notification")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends Base {
 
+    /**
+     * 알림의 고유 식별자입니다. 자동 생성되는 ID 값입니다.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id", updatable = false)
     private Long id;
 
+    /**
+     * 알림을 받는 사용자를 나타냅니다. Member 엔티티와의 다대일(N:1) 관계를 맺고 있습니다.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
 
+    /**
+     * 알림을 보낸 사용자의 ID를 나타냅니다. 알림을 생성한 사용자의 식별자입니다.
+     */
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    /**
+     * 알림과 관련된 게시물의 ID입니다.
+     */
     @Column(name = "post_id", nullable = false)
     private Long postId;
 
+    /**
+     * 알림의 유형을 나타냅니다. NotificationType 열거형을 사용하여 알림의 유형을 정의합니다.
+     */
     @Enumerated(EnumType.STRING)
     @Column(name = "notification_type", nullable = false)
     private NotificationType notificationType;
 
+    /**
+     * 알림의 읽음 여부를 나타냅니다. 기본값은 false(읽지 않음)입니다.
+     */
     @Column(name = "is_read", nullable = false)
     private Boolean isRead;
 
+    /**
+     * 알림 객체를 생성할 때 사용하는 빌더 메서드입니다.
+     *
+     * @param receiver         알림을 받는 사용자
+     * @param senderId         알림을 보낸 사용자의 ID
+     * @param postId           알림과 관련된 게시물 ID
+     * @param notificationType 알림의 유형
+     * @param isRead           알림의 읽음 여부
+     */
     @Builder
-    public Notification(Member member, Long postId, NotificationType notificationType,
+    public Notification(Member receiver, Long senderId, Long postId,
+            NotificationType notificationType,
             Boolean isRead) {
-        this.member = member;
+        this.receiver = receiver;
+        this.senderId = senderId;
         this.postId = postId;
         this.notificationType = notificationType;
         this.isRead = isRead;
     }
 
+    /**
+     * 알림을 읽음 상태로 변경하는 메서드입니다.
+     */
     public void readNotification() {
         this.isRead = true;
     }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationException.java
@@ -1,0 +1,18 @@
+package com.example.favoriteschoolmeal.domain.notification.exception;
+
+import com.example.favoriteschoolmeal.global.exception.BaseException;
+import com.example.favoriteschoolmeal.global.exception.BaseExceptionType;
+
+public class NotificationException extends BaseException {
+
+    private final NotificationExceptionType notificationExceptionType;
+
+    public NotificationException(final NotificationExceptionType notificationExceptionType) {
+        this.notificationExceptionType = notificationExceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return notificationExceptionType;
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
@@ -5,6 +5,12 @@ import org.springframework.http.HttpStatus;
 
 public enum NotificationExceptionType implements BaseExceptionType {
 
+    NOTIFICATION_NOT_FOUND(
+            404,
+            HttpStatus.NOT_FOUND,
+            "Notification not found"
+    ),
+
     MEMBER_NOT_FOUND(
             404,
             HttpStatus.NOT_FOUND,

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
@@ -1,0 +1,38 @@
+package com.example.favoriteschoolmeal.domain.notification.exception;
+
+import com.example.favoriteschoolmeal.global.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum NotificationExceptionType implements BaseExceptionType {
+
+    MEMBER_NOT_FOUND(
+            404,
+            HttpStatus.NOT_FOUND,
+            "Member not found"
+    );
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    NotificationExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
@@ -15,6 +15,12 @@ public enum NotificationExceptionType implements BaseExceptionType {
             404,
             HttpStatus.NOT_FOUND,
             "Member not found"
+    ),
+
+    UNAUTHORIZED_ACCESS(
+            401,
+            HttpStatus.UNAUTHORIZED,
+            "Unauthorized access"
     );
 
     private final int errorCode;

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.example.favoriteschoolmeal.domain.notification.repository;
+
+import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -1,10 +1,28 @@
 package com.example.favoriteschoolmeal.domain.notification.repository;
 
+import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    /**
+     * 특정 멤버의 모든 알림을 조회합니다.
+     *
+     * @param member 알림을 조회할 멤버 객체
+     * @return 주어진 멤버에 대한 알림 리스트
+     */
+    List<Notification> findAllByMember(Member member);
+
+    /**
+     * 멤버에게 안 읽은 알림이 있는지 여부를 확인합니다.
+     *
+     * @param member 멤버 객체
+     * @param isRead 읽음 상태
+     * @return 안 읽은 알림 존재 여부
+     */
+    boolean existsByMemberAndIsRead(Member member, boolean isRead);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -12,17 +12,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     /**
      * 특정 멤버의 모든 알림을 조회합니다.
      *
-     * @param member 알림을 조회할 멤버 객체
+     * @param receiver 알림을 조회할 멤버 객체
      * @return 주어진 멤버에 대한 알림 리스트
      */
-    List<Notification> findAllByMember(Member member);
+    List<Notification> findAllByReceiver(Member receiver);
 
     /**
      * 멤버에게 안 읽은 알림이 있는지 여부를 확인합니다.
      *
-     * @param member 멤버 객체
-     * @param isRead 읽음 상태
+     * @param receiver 멤버 객체
+     * @param isRead   읽음 상태
      * @return 안 읽은 알림 존재 여부
      */
-    boolean existsByMemberAndIsRead(Member member, boolean isRead);
+    boolean existsByReceiverAndIsRead(Member receiver, boolean isRead);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
@@ -3,10 +3,18 @@ package com.example.favoriteschoolmeal.domain.notification.service;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.member.service.MemberService;
 import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationListResponse;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationResponse;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.UnreadNotificationStatusResponse;
 import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationException;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationExceptionType;
 import com.example.favoriteschoolmeal.domain.notification.repository.NotificationRepository;
+import com.example.favoriteschoolmeal.domain.post.exception.PostException;
+import com.example.favoriteschoolmeal.domain.post.exception.PostExceptionType;
+import com.example.favoriteschoolmeal.global.security.util.SecurityUtils;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +43,30 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    public NotificationListResponse findAllNotification() {
+        Member member = getMemberOrThrow(getCurrentMemberId());
+        List<NotificationResponse> notificationResponseList = notificationRepository
+                .findAllByMember(member)
+                .stream()
+                .map(NotificationResponse::from)
+                .collect(Collectors.toList());
+        return NotificationListResponse.from(notificationResponseList);
+    }
+
+    public UnreadNotificationStatusResponse hasUnreadNotifications() {
+        Member member = getMemberOrThrow(getCurrentMemberId());
+        return UnreadNotificationStatusResponse.from(
+                notificationRepository.existsByMemberAndIsRead(member, false));
+    }
+
     private Member getMemberOrThrow(final Long memberId) {
         return memberService.findMemberOptionally(memberId)
-                .orElseThrow(() -> new NotificationException(NotificationExceptionType.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotificationException(
+                        NotificationExceptionType.MEMBER_NOT_FOUND));
+    }
+
+    private Long getCurrentMemberId() {
+        return SecurityUtils.getCurrentMemberId(
+                () -> new PostException(PostExceptionType.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
@@ -1,0 +1,42 @@
+package com.example.favoriteschoolmeal.domain.notification.service;
+
+import com.example.favoriteschoolmeal.domain.member.domain.Member;
+import com.example.favoriteschoolmeal.domain.member.service.MemberService;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+import com.example.favoriteschoolmeal.domain.notification.exception.NotificationException;
+import com.example.favoriteschoolmeal.domain.notification.exception.NotificationExceptionType;
+import com.example.favoriteschoolmeal.domain.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberService memberService;
+
+    public NotificationService(final NotificationRepository notificationRepository,
+            final MemberService memberService) {
+        this.notificationRepository = notificationRepository;
+        this.memberService = memberService;
+    }
+
+    public void createNotification(final Long postId, final Long memberId,
+            final NotificationType notificationType) {
+        Member member = getMemberOrThrow(memberId);
+        Notification notification = Notification.builder()
+                .member(member)
+                .postId(postId)
+                .notificationType(notificationType)
+                .isRead(false)
+                .build();
+        notificationRepository.save(notification);
+    }
+
+    private Member getMemberOrThrow(final Long memberId) {
+        return memberService.findMemberOptionally(memberId)
+                .orElseThrow(() -> new NotificationException(NotificationExceptionType.MEMBER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #80
closed #81
closed #82
closed #83
closed #84

## 🛠️ 작업 내용
- [x] **알림 목록 조회**: 사용자의 모든 알림을 조회할 수 있습니다.
- [x] **안 읽은 알림 존재 여부 확인**: 안 읽은 알림 존재 여부를 true/false로 반환합니다. 메인 페이지에 사용하기 위한 기능입니다.
- [x] **알림 읽음 상태 변경**: 알림 목록 조회에서 클릭하여 관련 페이지를 조회할 경우, 해당 api를 요청해 isRead를 true로 변경합니다.
- [x] **알림 생성 기능**: 알림 종류에 따라 자동으로 알림을 생성하고 저장합니다.

## 🎯 리뷰 포인트

### 알림 종류
1. 댓글 작성 시 해당 post 작성자에게 알림
2. guest가 매칭 요청 시 host에게 알림
3. guest가 매칭 취소 시 host에게 알림
4. host가 guest의 매칭 승인 시 guest에게 알림
5. host가 guest의 매칭 거절 시 guest에게 알림
6. host가 매칭 상태 모집 완료로 변경 시 매칭 승인된 guest에게 알림

## ✅ 테스트 결과
- 알림 목록 조회
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/399137d9-c621-4c32-b3bd-8db77197c5d7)
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/56cb0fed-9070-43db-9097-c40de0035c2d)


- 안 읽은 알림 존재 여부 확인
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/88f27431-6724-4af3-ad77-e3db29d5ce35)
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/d86e3af0-24fd-4816-b7c2-41f3b521e45b)


- 알림 읽음 상태로 변경
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/5635b514-72b3-49f2-926e-8f63fdf42d1c)
