### PR TITLE
feature: 특정 회원이 작성한 게시물 목록 조회, 특정 회원의 매칭 횟수 조회 구현

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/controller/MatchingController.java
@@ -1,9 +1,11 @@
 package com.example.favoriteschoolmeal.domain.matching.controller;
 
+import com.example.favoriteschoolmeal.domain.matching.controller.dto.MemberMatchingCountResponse;
 import com.example.favoriteschoolmeal.domain.matching.service.MatchingService;
 import com.example.favoriteschoolmeal.global.common.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/v1/posts/{postId}")
+@RequestMapping("/api/v1")
 @RestController
 public class MatchingController {
 
@@ -21,7 +23,7 @@ public class MatchingController {
         this.matchingService = matchingService;
     }
 
-    @PostMapping("/apply-matching")
+    @PostMapping("/posts/{postId}/apply-matching")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<Void> matchingApply(
             @PathVariable final Long postId) {
@@ -29,7 +31,7 @@ public class MatchingController {
         return ApiResponse.createSuccess(null);
     }
 
-    @DeleteMapping("/cancel-application")
+    @DeleteMapping("/posts/{postId}/cancel-application")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ApiResponse<Void> matchingApplicationCancel(
             @PathVariable final Long postId) {
@@ -37,7 +39,7 @@ public class MatchingController {
         return ApiResponse.createSuccess(null);
     }
 
-    @PatchMapping("/accept-application/{memberId}")
+    @PatchMapping("/posts/{postId}/accept-application/{memberId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<Void> matchingApplicationAccept(
             @PathVariable final Long postId,
@@ -46,7 +48,7 @@ public class MatchingController {
         return ApiResponse.createSuccess(null);
     }
 
-    @PatchMapping("/reject-application/{memberId}")
+    @PatchMapping("/posts/{postId}/reject-application/{memberId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<Void> matchingApplicationReject(
             @PathVariable final Long postId,
@@ -55,11 +57,19 @@ public class MatchingController {
         return ApiResponse.createSuccess(null);
     }
 
-    @PatchMapping("/complete-matching")
+    @PatchMapping("/posts/{postId}/complete-matching")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<Void> matchingComplete(
             @PathVariable final Long postId) {
         matchingService.completeMatching(postId);
         return ApiResponse.createSuccess(null);
+    }
+
+    @GetMapping("/members/{memberId}/matching-count")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<MemberMatchingCountResponse> matchingCount(
+            @PathVariable final Long memberId) {
+        final MemberMatchingCountResponse response = matchingService.countMatching(memberId);
+        return ApiResponse.createSuccess(response);
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/controller/dto/MemberMatchingCountResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/controller/dto/MemberMatchingCountResponse.java
@@ -1,0 +1,11 @@
+package com.example.favoriteschoolmeal.domain.matching.controller.dto;
+
+public record MemberMatchingCountResponse(
+        long matchingCount) {
+
+    public static MemberMatchingCountResponse from(final long matchingCount) {
+        return new MemberMatchingCountResponse(
+                matchingCount
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/repository/MatchingMemberRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/repository/MatchingMemberRepository.java
@@ -47,4 +47,12 @@ public interface MatchingMemberRepository extends JpaRepository<MatchingMember, 
      */
     List<MatchingMember> findByMatchingAndMatchingRequestStatus(Matching matching,
             MatchingRequestStatus status);
+
+    /**
+     * 주어진 멤버와 관련된 모든 매칭 멤버를 조회합니다.
+     *
+     * @param member 조회할 멤버 엔티티
+     * @return 해당 멤버에 연관된 MatchingMember 리스트
+     */
+    List<MatchingMember> findAllByMember(Member member);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
@@ -130,7 +130,6 @@ public class MatchingService {
      */
     @Transactional(readOnly = true)
     public MemberMatchingCountResponse countMatching(final Long memberId) {
-        verifyRequesterOrAdmin(memberId);
         Member member = getMemberOrThrow(memberId);
         List<MatchingMember> matchingMembers = matchingMemberRepository.findAllByMember(member);
         long count = calculateValidMatchingCount(matchingMembers);
@@ -291,18 +290,6 @@ public class MatchingService {
     private void verifyMatchingStatus(final Matching matching, final MatchingStatus status) {
         if (!matching.getMatchingStatus().equals(status)) {
             throw new MatchingException(MatchingExceptionType.INVALID_OPERATION);
-        }
-    }
-
-    /**
-     * 요청한 사용자가 해당 멤버 또는 관리자인지 확인합니다.
-     *
-     * @param memberId 검증할 멤버의 ID
-     */
-    private void verifyRequesterOrAdmin(Long memberId) {
-        Long currentMemberId = getCurrentMemberId();
-        if (!currentMemberId.equals(memberId) && !SecurityUtils.isAdmin()) {
-            throw new MatchingException(MatchingExceptionType.UNAUTHORIZED_ACCESS);
         }
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/post/controller/PostController.java
@@ -69,6 +69,15 @@ public class PostController {
         return ApiResponse.createSuccess(response);
     }
 
+    @GetMapping("/members/{memberId}/posts")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<PaginatedPostListResponse> postListByMemberId(
+            @PathVariable Long memberId, Pageable pageable) {
+        final PaginatedPostListResponse response = postService.findAllPostByMemberId(pageable,
+                memberId);
+        return ApiResponse.createSuccess(response);
+    }
+
     @GetMapping("/posts/{postId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<PostDetailResponse> postDetails(@PathVariable Long postId) {

--- a/src/main/java/com/example/favoriteschoolmeal/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,5 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllOrderByStatusAndTime(Pageable pageable);
 
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.matching m WHERE p.restaurant.id = :restaurantId ORDER BY m.matchingStatus DESC, p.createdAt DESC")
-    Page<Post> findAllByRestaurantIdOrderByStatusAndTime(Pageable pageable, Long restaurantId);
+    Page<Post> findAllByRestaurantIdOrderByStatusAndTime(Pageable pageable, @Param("restaurantId") Long restaurantId);
+
+    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.matching m WHERE p.member.id = :memberId ORDER BY m.matchingStatus DESC, p.createdAt DESC")
+    Page<Post> findAllByMemberIdOrderByStatusAndTime(Pageable pageable, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/post/repository/PostRepository.java
@@ -15,8 +15,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllOrderByStatusAndTime(Pageable pageable);
 
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.matching m WHERE p.restaurant.id = :restaurantId ORDER BY m.matchingStatus DESC, p.createdAt DESC")
-    Page<Post> findAllByRestaurantIdOrderByStatusAndTime(Pageable pageable, @Param("restaurantId") Long restaurantId);
+    Page<Post> findAllByRestaurantIdOrderByStatusAndTime(Pageable pageable,
+            @Param("restaurantId") Long restaurantId);
 
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.matching m WHERE p.member.id = :memberId ORDER BY m.matchingStatus DESC, p.createdAt DESC")
-    Page<Post> findAllByMemberIdOrderByStatusAndTime(Pageable pageable, @Param("memberId") Long memberId);
+    Page<Post> findAllByMemberIdOrderByStatusAndTime(Pageable pageable,
+            @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/post/service/PostService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/post/service/PostService.java
@@ -94,6 +94,18 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    public PaginatedPostListResponse findAllPostByMemberId(final Pageable pageable,
+            final Long memberId) {
+        final Page<Post> posts = postRepository.findAllByMemberIdOrderByStatusAndTime(pageable,
+                memberId);
+        summarizePostsIfNotNull(posts);
+        List<PostSummaryResponse> postSummaryResponses = posts.stream()
+                .map(this::convertToPostSummaryResponse).toList();
+        return PaginatedPostListResponse.from(postSummaryResponses, posts.getNumber(),
+                posts.getTotalPages(), posts.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
     public PostDetailResponse findPost(final Long postId) {
         final Post post = getPostOrThrow(postId);
         return PostDetailResponse.from(post,


### PR DESCRIPTION
## 📌 관련 이슈
closed #94
closed #95
closed #96

## 🛠️ 작업 내용
- [x] 특정 회원이 작성한 게시물 목록 조회 기능 구현
- [x] 특정 회원의 매칭 횟수 조회 기능 구현

## 🎯 리뷰 포인트
- 코드의 가독성 및 유지보수 측면에서의 접근 방식
- 성능 및 데이터데이스 효율성에 대한 고려
- 예외 처리 및 데이터 검증 로직의 적절성

### 🖋️ 고민의 과정
#### 특정회원의 매칭 횟수 조회 기능 구현

**요구사항 분석 및 정의**
특정 사용자의 매칭 횟수 계산하는 요구 사항을 다음과 같이 정의하였습니다.

1. **대상 사용자 정의**: 특정 사용자의 매칭 횟수를 계산합니다. 여기서 `특정 사용자`란 메소드에 전달되는 사용자 ID를 가진 사용자를 의미합니다.
2. **매칭 상태 필터링**: 해당 사용자가 참여한 매칭 중 `MatchingStatus`가 `CLOSED`인 매칭만을 고려합니다. 즉, 완료된 매칭만 계산 대상이 됩니다.
3. **매칭 멤버 상태 확인**: 각 매칭에서 해당 사용자는 `MatchingMember`의 `MatchingRequestStatus`가 `ACCEPTED`인 상태여야 합니다. 이는 해당 사용자가 매칭에 성공적으로 참여했음을 나타냅니다.
4. **매칭 멤버 최소 조건**: 유효한 매칭으로 간주하기 위해서는 해당 매칭의 `ACCEPTED` 상태인 `MatchingMember`의 수가 최소 2명 이상이어야 합니다. 즉, 사용자 본인 외에 최소 한 명 이상이 매칭에 참여했어야 합니다.
5. **결과 반환**: 위 조건을 만족하는 매칭의 수를 계산하여 반환합니다. 이 값은 특정 사용자의 유효한 매칭 횟수를 나타냅니다.

**설계 및 접근 방법 결정**
간단한 프로젝트라는 특성을 고려하여, 코드의 가독성과 유지보수의 용이성을 최우선으로 두었습니다. 이러한 결정으로 복잡한 SQL 쿼리 작성대신 자바 스트림과 JPA의 기능을 적극적으로 활용하는 방향으로 구현하였습니다.

## ✅ 테스트 결과
- 특정 회원이 작성한 게시물 목록 조회 기능 구현
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/779c7b62-5152-402f-ad3d-33e8101820b7)

- 특정 회원의 매칭 횟수 조회 기능 구현
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/a6bcfb66-bf7a-48f1-8f6b-0ae2169bc183)
