### PR TITLE
feat: 회원 프로필 이미지 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/controller/FileController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/controller/FileController.java
@@ -27,9 +27,6 @@ public class FileController {
 
     private final FileService fileService;
 
-    @Value("${file.dir}")
-    private String fileDir;
-
      /**
       * /images/{savedName} 형식으로 요청하면 해당 이미지를 불러옵니다.
       *
@@ -48,17 +45,4 @@ public class FileController {
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_JPEG_VALUE)
                 .body(resource);
     }
-
-    /**
-     * 테스트용 업로드 api
-     * 추후 삭제 예정
-     * 작성자: 염동환
-     */
-    @PostMapping("/upload")
-    public ResponseEntity<String> uploadFile(MultipartFile files) {
-        Long savedFileId = fileService.saveFile(files);
-        return ResponseEntity.ok(fileService.getImageUrlOrNullByFileId(savedFileId));
-
-    }
-
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/domain/FileEntity.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/domain/FileEntity.java
@@ -18,13 +18,14 @@ public class FileEntity {
 
     private String savedPath;
 
-    private String url;
+    // 이미지를 불러올 때 사용할 경로
+    private String endpoint;
 
     @Builder
-    public FileEntity(String originalName, String savedName, String savedPath, String url) {
+    public FileEntity(String originalName, String savedName, String savedPath, String endpoint) {
         this.originalName = originalName;
         this.savedName = savedName;
         this.savedPath = savedPath;
-        this.url = url;
+        this.endpoint = endpoint;
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/domain/FileEntity.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/domain/FileEntity.java
@@ -18,10 +18,13 @@ public class FileEntity {
 
     private String savedPath;
 
+    private String url;
+
     @Builder
-    public FileEntity(String originalName, String savedName, String savedPath) {
+    public FileEntity(String originalName, String savedName, String savedPath, String url) {
         this.originalName = originalName;
         this.savedName = savedName;
         this.savedPath = savedPath;
+        this.url = url;
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
@@ -29,7 +29,7 @@ public class FileService {
     private final FileRepository fileRepository;
 
     // 이미지를 불러올 때 사용할 경로
-    private static final String viewPath = "/api/v1/images/";
+    private final String viewPath = "/api/v1/images/";
 
     /**
      * 파일을 저장하고 저장된 파일의 id를 반환하는 메서드입니다.
@@ -67,7 +67,7 @@ public class FileService {
         }
         return resource;
     }
-    private static FileEntity createFileEntity(String origName, String savedName, String savedPath) {
+    private FileEntity createFileEntity(String origName, String savedName, String savedPath) {
         return FileEntity.builder()
                 .originalName(origName)
                 .savedName(savedName)
@@ -80,7 +80,7 @@ public class FileService {
     /**
      * 실제로 로컬에 파일을 저장하는 메서드입니다.
      * */
-    private static void transferFileToSavedPath(MultipartFile files, String savedPath) {
+    private void transferFileToSavedPath(MultipartFile files, String savedPath) {
         try {
             files.transferTo(new File(savedPath));
         } catch (IOException e) {
@@ -88,7 +88,7 @@ public class FileService {
         }
     }
 
-    private static String getSavedNameOrThrow(String origName) {
+    private String getSavedNameOrThrow(String origName) {
         // 파일 이름으로 쓸 uuid 생성
         String uuid = UUID.randomUUID().toString();
 
@@ -98,7 +98,7 @@ public class FileService {
         return uuid + extension;
     }
 
-    private static String getExtensionOrThrow(String origName) {
+    private String getExtensionOrThrow(String origName) {
         // 확장자 추출(ex : .jpg) 현재 jpg만 허용
         String extension = origName.substring(origName.lastIndexOf("."));
         if (!extension.equalsIgnoreCase(".jpg")) {
@@ -107,7 +107,7 @@ public class FileService {
         return extension;
     }
 
-    private static String getOriginalNameOrThrow(MultipartFile files) {
+    private String getOriginalNameOrThrow(MultipartFile files) {
         // 원래 파일 이름 추출
         String origName = files.getOriginalFilename();
         if (origName == null || origName.isEmpty()) {

--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
@@ -29,7 +29,7 @@ public class FileService {
     private final FileRepository fileRepository;
 
     // 이미지를 불러올 때 사용할 경로
-    private final String viewPath = "/api/v1/images/";
+    private static final String viewPath = "/api/v1/images/";
 
     /**
      * 파일을 저장하고 저장된 파일의 id를 반환하는 메서드입니다.
@@ -57,21 +57,6 @@ public class FileService {
         return fileRepository.findById(id);
     }
 
-    /**
-     * 파일 id를 받아 해당 파일의 조회 URL을 반환하는 메서드입니다.
-     * 파일이 존재하지 않거나 fildId가 null이면 null을 반환합니다.
-     *
-     * @param fileId 파일 id
-     * @return 파일 조회 URL
-     */
-    public String getImageUrlOrNullByFileId(Long fileId) {
-        if (fileId == null) {
-            return null;
-        }
-        Optional<FileEntity> file = findFileOptionally(fileId);
-        return file.map(f -> viewPath + f.getSavedName()).orElse(null);
-    }
-
     public Resource loadFileAsResource(String savedName) {
         String savedPath = fileDir + savedName;
         Resource resource;
@@ -87,6 +72,7 @@ public class FileService {
                 .originalName(origName)
                 .savedName(savedName)
                 .savedPath(savedPath)
+                .url(viewPath + savedName)
                 .build();
     }
 

--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
@@ -72,7 +72,7 @@ public class FileService {
                 .originalName(origName)
                 .savedName(savedName)
                 .savedPath(savedPath)
-                .url(viewPath + savedName)
+                .endpoint(viewPath + savedName)
                 .build();
     }
 

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/api/MemberController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/api/MemberController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -27,6 +28,18 @@ public class MemberController {
                                                           @RequestBody final ModifyMemberRequest request) {
 
         final MemberDetailResponse response = memberService.modifyMember(request, memberId);
+        return ApiResponse.createSuccess(response);
+    }
+
+    /**
+     * 프로필 이미지 업로드 API
+     * */
+    @PostMapping("/members/{memberId}/profile-image")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<MemberDetailResponse> memberProfileImageSave(@PathVariable final Long memberId,
+                                                                    MultipartFile file) {
+
+        final MemberDetailResponse response = memberService.saveProfileImage(memberId,file);
         return ApiResponse.createSuccess(response);
     }
 

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.favoriteschoolmeal.domain.member.domain;
 
+import com.example.favoriteschoolmeal.domain.file.domain.FileEntity;
 import com.example.favoriteschoolmeal.domain.model.Authority;
 import com.example.favoriteschoolmeal.domain.model.Gender;
 import com.example.favoriteschoolmeal.global.common.Base;
@@ -52,6 +53,9 @@ public class Member extends Base {
     @Column(name = "introduction", length = 300)
     private String introduction;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_id")
+    private FileEntity profileImage;
     @Builder
     public Member(String username, String nickname, String fullName, String password, String email, Authority authority, LocalDateTime unblockDate, Integer age, Gender gender, String introduction) {
         this.username = username;
@@ -72,6 +76,10 @@ public class Member extends Base {
         else{
             this.unblockDate = this.unblockDate.plusHours(blockHours);
         }
+    }
+
+    public void changeProfileImage(FileEntity fileEntity) {
+        this.profileImage = fileEntity;
     }
 
     public boolean isBanned() {

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
@@ -15,7 +15,7 @@ public record MemberDetailResponse(
         Integer age,
         Gender gender,
         String introduction,
-        String profileImageUrl
+        String profileImageEndpoint
 ) {
 
     public static MemberDetailResponse from(final Member member){
@@ -28,7 +28,7 @@ public record MemberDetailResponse(
                 member.getGender(),
                 member.getIntroduction(),
                 Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getUrl)
+                        .map(FileEntity::getEndpoint)
                         .orElse(null)
         );
     }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
@@ -1,7 +1,10 @@
 package com.example.favoriteschoolmeal.domain.member.dto;
 
+import com.example.favoriteschoolmeal.domain.file.domain.FileEntity;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.model.Gender;
+
+import java.util.Optional;
 
 
 public record MemberDetailResponse(
@@ -11,7 +14,9 @@ public record MemberDetailResponse(
         String email,
         Integer age,
         Gender gender,
-        String introduction) {
+        String introduction,
+        String profileImageUrl
+) {
 
     public static MemberDetailResponse from(final Member member){
         return new MemberDetailResponse(
@@ -21,8 +26,10 @@ public record MemberDetailResponse(
                 member.getEmail(),
                 member.getAge(),
                 member.getGender(),
-                member.getIntroduction()
-
+                member.getIntroduction(),
+                Optional.ofNullable(member.getProfileImage())
+                        .map(FileEntity::getUrl)
+                        .orElse(null)
         );
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
@@ -7,14 +7,14 @@ import java.util.Optional;
 
 public record MemberSimpleResponse(
         String nickname,
-        String profileImageUrl) {
+        String profileImageEndpoint) {
 
     public static MemberSimpleResponse from(final Member member) {
 
         return new MemberSimpleResponse(
                 member.getNickname(),
                 Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getUrl)
+                        .map(FileEntity::getEndpoint)
                         .orElse(null));
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
@@ -1,11 +1,20 @@
 package com.example.favoriteschoolmeal.domain.member.dto;
 
+import com.example.favoriteschoolmeal.domain.file.domain.FileEntity;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 
-public record MemberSimpleResponse(String nickname) {
+import java.util.Optional;
+
+public record MemberSimpleResponse(
+        String nickname,
+        String profileImageUrl) {
 
     public static MemberSimpleResponse from(final Member member) {
 
-        return new MemberSimpleResponse(member.getNickname());
+        return new MemberSimpleResponse(
+                member.getNickname(),
+                Optional.ofNullable(member.getProfileImage())
+                        .map(FileEntity::getUrl)
+                        .orElse(null));
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
@@ -20,7 +20,7 @@ public record MemberSummaryResponse(
         Integer age,
         Gender gender,
         String introduction,
-        String profileImageUrl
+        String profileImageEndpoint
 ) {
 
     public static MemberSummaryResponse from(final Member member){
@@ -36,7 +36,7 @@ public record MemberSummaryResponse(
                 member.getGender(),
                 member.getIntroduction(),
                 Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getUrl)
+                        .map(FileEntity::getEndpoint)
                         .orElse(null)
         );
     }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
@@ -3,8 +3,10 @@ package com.example.favoriteschoolmeal.domain.member.dto;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.model.Authority;
 import com.example.favoriteschoolmeal.domain.model.Gender;
+import com.example.favoriteschoolmeal.domain.file.domain.FileEntity;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record MemberSummaryResponse(
 
@@ -17,7 +19,9 @@ public record MemberSummaryResponse(
         LocalDateTime unblockDate,
         Integer age,
         Gender gender,
-        String introduction) {
+        String introduction,
+        String profileImageUrl
+) {
 
     public static MemberSummaryResponse from(final Member member){
         return new MemberSummaryResponse(
@@ -30,7 +34,10 @@ public record MemberSummaryResponse(
                 member.getUnblockDate(),
                 member.getAge(),
                 member.getGender(),
-                member.getIntroduction()
+                member.getIntroduction(),
+                Optional.ofNullable(member.getProfileImage())
+                        .map(FileEntity::getUrl)
+                        .orElse(null)
         );
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/exception/MemberExceptionType.java
@@ -22,7 +22,12 @@ public enum MemberExceptionType implements BaseExceptionType {
             403,
             HttpStatus.FORBIDDEN,
             "Member blocked"
-    ),;
+    ),
+    FILE_NOT_FOUND(
+            404,
+            HttpStatus.NOT_FOUND,
+            "File not found"
+    );
 
 
     private final int errorCode;

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.example.favoriteschoolmeal.domain.member.service;
 
+import com.example.favoriteschoolmeal.domain.file.domain.FileEntity;
+import com.example.favoriteschoolmeal.domain.file.service.FileService;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.member.dto.*;
 import com.example.favoriteschoolmeal.domain.member.exception.MemberException;
@@ -11,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,7 +24,7 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-
+    private final FileService fileService;
 
     public Optional<Member> findMemberOptionally(Long memberId) {
         return memberRepository.findById(memberId);
@@ -32,7 +35,7 @@ public class MemberService {
     }
 
 
-    public MemberDetailResponse modifyMember(final ModifyMemberRequest request, final Long memberId){
+    public MemberDetailResponse modifyMember(final ModifyMemberRequest request, final Long memberId) {
 
         verifyUserOrAdmin();
         final Long currentMemberId = getCurrentMemberId();
@@ -46,21 +49,35 @@ public class MemberService {
         return MemberDetailResponse.from(savedMember);
     }
 
+    public MemberDetailResponse saveProfileImage(Long memberId, MultipartFile file) {
+        verifyUserOrAdmin();
+        final Long currentMemberId = getCurrentMemberId();
+
+        final Member member = getMemberOrThrow(memberId);
+        verifyMemberOwner(memberId, currentMemberId);
+
+        final Long fileId = fileService.saveFile(file);
+        FileEntity fileEntity = getFileEntityOrThrow(fileId);
+        member.changeProfileImage(fileEntity);
+
+        return MemberDetailResponse.from(member);
+    }
+
     @Transactional(readOnly = true)
-    public MemberDetailResponse findDetailMember(final Long memberId){
+    public MemberDetailResponse findDetailMember(final Long memberId) {
 
         final Member member = getMemberOrThrow(memberId);
         return MemberDetailResponse.from(member);
     }
 
     @Transactional(readOnly = true)
-    public MemberSimpleResponse findSimpleMember(final Long memberId){
+    public MemberSimpleResponse findSimpleMember(final Long memberId) {
         final Member member = getMemberOrThrow(memberId);
         return MemberSimpleResponse.from(member);
     }
 
     @Transactional(readOnly = true)
-    public MemberDetailResponse findCurrentMember(){
+    public MemberDetailResponse findCurrentMember() {
 
         final Long currentMemberId = getCurrentMemberId();
         final Member member = getMemberOrThrow(currentMemberId);
@@ -69,7 +86,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public PaginatedMemberListResponse findAllMember(final Pageable pageable){
+    public PaginatedMemberListResponse findAllMember(final Pageable pageable) {
 
         verifyAdmin();
 
@@ -83,42 +100,42 @@ public class MemberService {
                 members.getTotalPages(), members.getTotalElements());
     }
 
-    private void modifyIntroduction(final Member member, final ModifyMemberRequest request){
+    private void modifyIntroduction(final Member member, final ModifyMemberRequest request) {
         member.modifyIntroduction(request.introduction());
     }
 
-    private Member getMemberOrThrow(final Long memberId){
+    private Member getMemberOrThrow(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
     }
 
 
-    private void verifyUserOrAdmin(){
+    private void verifyUserOrAdmin() {
         SecurityUtils.checkUserOrAdminOrThrow(
                 () -> new MemberException(MemberExceptionType.UNAUTHORIZED_ACCESS));
     }
 
-    private void verifyAdmin(){
+    private void verifyAdmin() {
         SecurityUtils.checkAdminOrThrow(
                 () -> new MemberException(MemberExceptionType.UNAUTHORIZED_ACCESS));
     }
 
-    private void verifyMemberOwner(final Long memberOwnerId, final Long currentMemberId){
-        if(!memberOwnerId.equals(currentMemberId)){
+    private void verifyMemberOwner(final Long memberOwnerId, final Long currentMemberId) {
+        if (!memberOwnerId.equals(currentMemberId)) {
             throw new MemberException(MemberExceptionType.UNAUTHORIZED_ACCESS);
         }
     }
 
-    private Long getCurrentMemberId(){
+    private Long getCurrentMemberId() {
         return SecurityUtils.getCurrentMemberId(
                 () -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
     }
 
-    private MemberSummaryResponse convertToSummaryResponse(final Member member){
+    private MemberSummaryResponse convertToSummaryResponse(final Member member) {
         return MemberSummaryResponse.from(member);
     }
 
-    private void summarizeIntroduction(final Member member){
+    private void summarizeIntroduction(final Member member) {
         String summarizedIntroduction = Optional.ofNullable(member.getIntroduction())
                 .filter(introduction -> introduction.length() > 50)
                 .map(introduction -> introduction.substring(0, 50) + "...")
@@ -127,11 +144,14 @@ public class MemberService {
         member.summarizeIntroduction(summarizedIntroduction);
     }
 
-    private void summarizeMembersIfNotNull(Page<Member> members){
-        if(!members.isEmpty()){
+    private void summarizeMembersIfNotNull(Page<Member> members) {
+        if (!members.isEmpty()) {
             members.forEach(this::summarizeIntroduction);
         }
     }
-
+    private FileEntity getFileEntityOrThrow(Long fileId) {
+        return fileService.findFileOptionally(fileId)
+                .orElseThrow(() -> new MemberException(MemberExceptionType.FILE_NOT_FOUND));
+    }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #91 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 회원 프로필 이미지 업로드 기능 구현
- [x] 회원 조회시 프로필 이미지 url을 함께 제공하도록 추가

## 🎯 리뷰 포인트
FileEntity 엔티티에 String endpoint 필드가 추가되었습니다. 이 필드에는 이미지 조회용 endpoint를 담습니다.
(ex: /api/v1/images/abc.jpg)

프로필 이미지 기능을 구현하기 위해 member 엔티티에 FileEntity fileEntity 필드가 추가되었습니다.
이 필드는 null일 수 있습니다. 

회원 조회 DTO에는 각각 profileImageEndpoint필드가 추가되었습니다.
회원의 프로필 이미지가 등록되어 있지 않은 경우는 null을 반환하고, 프로필 이미지가 등록되어 있다면 조회용 endpoint를 넣어 반환할 수 있습니다.

프로필 이미지 업로드는 `api/v1/members/{memberId}/profile-image` 로 POST요청하면 됩니다. body는 form-data 형식으로 key="file":value=.jpg파일을 넣으면 됩니다.
<img width="710" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/0a5aa9ba-ff72-470f-83ad-ac18829006dd">

## ✅ 테스트 결과

### 회원 조회시

프로필 이미지가 등록되지 않은 회원
<img width="713" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/456acbaa-21fb-481d-b81a-f43bcaef11e6">

프로필 이미지가 등록
<img width="704" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/2116d950-ed3d-4fc0-866a-86ebb481d632">

profileImageEndpoint로 이미지 조회
<img width="715" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/848256cb-3f40-4e58-8837-1938c141d7c9">




