### PR TITLE
feat: 친구 관련 기능 추가로 인한 알림 기능 확장

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/comment/service/CommentService.java
@@ -38,7 +38,7 @@ public class CommentService {
         final Member member = getMemberOrThrow(getCurrentMemberId());
         final Comment comment = createComment(command, post, member);
         final Comment savedComment = commentRepository.save(comment);
-        notificationService.createNotification(member.getId(), post.getMember().getId(),
+        notificationService.createPostNotification(member.getId(), post.getMember().getId(),
                 post.getId(), NotificationType.COMMENT_POSTED);
         return savedComment;
     }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
@@ -62,7 +62,7 @@ public class MatchingService {
 
         checkIfMatchingIsAvailable(matching, applicant);
         addMatchingMember(matching, applicant);
-        notificationService.createNotification(applicant.getId(), post.getMember().getId(), postId,
+        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(), postId,
                 NotificationType.MATCHING_REQUESTED);
     }
 
@@ -74,22 +74,22 @@ public class MatchingService {
         final MatchingMember matchingMember = getMatchingMemberOrThrow(matching, applicant);
         verifyCancellation(matchingMember);
         cancelMatchingMember(matchingMember);
-        notificationService.createNotification(applicant.getId(), post.getMember().getId(), postId,
-                NotificationType.MATCHING_CANCELED);
+        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(), postId,
+                NotificationType.MATCHING_REQUEST_CANCELED);
     }
 
     public void acceptMatchingApplication(final Long postId, final Long applicantMemberId) {
         Post post = getPostOrThrow(postId);
         processMatchingApplication(post, applicantMemberId, MatchingRequestStatus.ACCEPTED);
-        notificationService.createNotification(post.getMember().getId(), applicantMemberId, postId,
-                NotificationType.MATCHING_ACCEPTED);
+        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId, postId,
+                NotificationType.MATCHING_REQUEST_ACCEPTED);
     }
 
     public void rejectMatchingApplication(final Long postId, final Long applicantMemberId) {
         Post post = getPostOrThrow(postId);
         processMatchingApplication(post, applicantMemberId, MatchingRequestStatus.REJECTED);
-        notificationService.createNotification(post.getMember().getId(), applicantMemberId, postId,
-                NotificationType.MATCHING_REJECTED);
+        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId, postId,
+                NotificationType.MATCHING_REQUEST_REJECTED);
     }
 
     public void completeMatching(final Long postId) {
@@ -196,7 +196,7 @@ public class MatchingService {
                         MatchingRequestStatus.ACCEPTED)
                 .stream()
                 .filter(matchingMember -> matchingMember.getRoleType().equals(RoleType.GUEST))
-                .forEach(matchingMember -> notificationService.createNotification(
+                .forEach(matchingMember -> notificationService.createPostNotification(
                         post.getMember().getId(), matchingMember.getMember().getId(), post.getId(),
                         NotificationType.MATCHING_COMPLETED));
     }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
@@ -62,7 +62,8 @@ public class MatchingService {
 
         checkIfMatchingIsAvailable(matching, applicant);
         addMatchingMember(matching, applicant);
-        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(), postId,
+        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(),
+                postId,
                 NotificationType.MATCHING_REQUESTED);
     }
 
@@ -74,21 +75,24 @@ public class MatchingService {
         final MatchingMember matchingMember = getMatchingMemberOrThrow(matching, applicant);
         verifyCancellation(matchingMember);
         cancelMatchingMember(matchingMember);
-        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(), postId,
+        notificationService.createPostNotification(applicant.getId(), post.getMember().getId(),
+                postId,
                 NotificationType.MATCHING_REQUEST_CANCELED);
     }
 
     public void acceptMatchingApplication(final Long postId, final Long applicantMemberId) {
         Post post = getPostOrThrow(postId);
         processMatchingApplication(post, applicantMemberId, MatchingRequestStatus.ACCEPTED);
-        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId, postId,
+        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId,
+                postId,
                 NotificationType.MATCHING_REQUEST_ACCEPTED);
     }
 
     public void rejectMatchingApplication(final Long postId, final Long applicantMemberId) {
         Post post = getPostOrThrow(postId);
         processMatchingApplication(post, applicantMemberId, MatchingRequestStatus.REJECTED);
-        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId, postId,
+        notificationService.createPostNotification(post.getMember().getId(), applicantMemberId,
+                postId,
                 NotificationType.MATCHING_REQUEST_REJECTED);
     }
 

--- a/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
@@ -41,19 +41,24 @@ public enum NotificationType {
     FRIEND_REQUESTED(7),
 
     /**
+     * 친구 요청이 취소되었을 경우의 알림 유형입니다.
+     */
+    FRIEND_REQUEST_CANCELLED(8),
+
+    /**
      * 친구 요청이 수락되었을 경우의 알림 유형입니다.
      */
-    FRIEND_REQUEST_ACCEPTED(8),
+    FRIEND_REQUEST_ACCEPTED(9),
 
     /**
      * 친구 요청이 거부되었을 경우의 알림 유형입니다.
      */
-    FRIEND_REQUEST_REJECTED(9),
+    FRIEND_REQUEST_REJECTED(10),
 
     /**
      * 친구가 제거되었을 경우의 알림 유형입니다.
      */
-    FRIEND_REMOVED(10);
+    FRIEND_REMOVED(11);
 
     private final int id;
 
@@ -88,7 +93,8 @@ public enum NotificationType {
      * @return 친구와 관련된 알림인지 여부
      */
     public boolean isFriendRelated() {
-        return this == FRIEND_REQUESTED || this == FRIEND_REQUEST_ACCEPTED
+        return this == FRIEND_REQUESTED || this == FRIEND_REQUEST_CANCELLED
+                || this == FRIEND_REQUEST_ACCEPTED
                 || this == FRIEND_REQUEST_REJECTED || this == FRIEND_REMOVED;
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/model/NotificationType.java
@@ -1,12 +1,59 @@
 package com.example.favoriteschoolmeal.domain.model;
 
+/**
+ * 알림의 유형을 정의하는 열거형 클래스입니다.
+ */
 public enum NotificationType {
+
+    /**
+     * 댓글이 게시된 경우의 알림 유형입니다.
+     */
     COMMENT_POSTED(1),
+
+    /**
+     * 매칭 요청이 발생했을 경우의 알림 유형입니다.
+     */
     MATCHING_REQUESTED(2),
-    MATCHING_CANCELED(3),
-    MATCHING_ACCEPTED(4),
-    MATCHING_REJECTED(5),
-    MATCHING_COMPLETED(6);
+
+    /**
+     * 매칭 요청이 취소되었을 경우의 알림 유형입니다.
+     */
+    MATCHING_REQUEST_CANCELED(3),
+
+    /**
+     * 매칭 요청이 수락되었을 경우의 알림 유형입니다.
+     */
+    MATCHING_REQUEST_ACCEPTED(4),
+
+    /**
+     * 매칭 요청이 거부되었을 경우의 알림 유형입니다.
+     */
+    MATCHING_REQUEST_REJECTED(5),
+
+    /**
+     * 매칭이 완료되었을 경우의 알림 유형입니다.
+     */
+    MATCHING_COMPLETED(6),
+
+    /**
+     * 친구 요청이 발생했을 경우의 알림 유형입니다.
+     */
+    FRIEND_REQUESTED(7),
+
+    /**
+     * 친구 요청이 수락되었을 경우의 알림 유형입니다.
+     */
+    FRIEND_REQUEST_ACCEPTED(8),
+
+    /**
+     * 친구 요청이 거부되었을 경우의 알림 유형입니다.
+     */
+    FRIEND_REQUEST_REJECTED(9),
+
+    /**
+     * 친구가 제거되었을 경우의 알림 유형입니다.
+     */
+    FRIEND_REMOVED(10);
 
     private final int id;
 
@@ -14,7 +61,34 @@ public enum NotificationType {
         this.id = id;
     }
 
+    /**
+     * 알림 유형의 식별자를 반환합니다.
+     *
+     * @return 알림 유형의 식별자
+     */
     public int getId() {
         return id;
+    }
+
+    /**
+     * 알림 유형이 게시물과 관련된 알림인지 확인합니다.
+     *
+     * @return 게시물과 관련된 알림인지 여부
+     */
+    public boolean isPostRelated() {
+        return this == COMMENT_POSTED || this == MATCHING_REQUESTED
+                || this == MATCHING_REQUEST_CANCELED
+                || this == MATCHING_REQUEST_ACCEPTED || this == MATCHING_REQUEST_REJECTED
+                || this == MATCHING_COMPLETED;
+    }
+
+    /**
+     * 알림 유형이 친구와 관련된 알림인지 확인합니다.
+     *
+     * @return 친구와 관련된 알림인지 여부
+     */
+    public boolean isFriendRelated() {
+        return this == FRIEND_REQUESTED || this == FRIEND_REQUEST_ACCEPTED
+                || this == FRIEND_REQUEST_REJECTED || this == FRIEND_REMOVED;
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/NotificationController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 알림 관련 요청을 처리하는 컨트롤러입니다.
+ * 이 클래스는 알림 리스트 조회, 안 읽은 알림 상태 확인, 특정 알림 읽음 처리 등의 API를 제공합니다.
+ */
 @RestController
 @RequestMapping("/api/v1/notifications")
 public class NotificationController {
@@ -23,6 +27,12 @@ public class NotificationController {
         this.notificationService = notificationService;
     }
 
+    /**
+     * 사용자의 모든 알림 목록을 조회하는 API입니다.
+     * HTTP 상태 코드 200(OK)와 함께 조회된 알림 목록을 반환합니다.
+     *
+     * @return ApiResponse<NotificationListResponse> 형태로 알림 목록을 반환
+     */
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<NotificationListResponse> notificationList() {
@@ -30,6 +40,12 @@ public class NotificationController {
         return ApiResponse.createSuccess(response);
     }
 
+    /**
+     * 사용자의 안 읽은 알림이 있는지 확인하는 API입니다.
+     * HTTP 상태 코드 200(OK)와 함께 안 읽은 알림 여부를 반환합니다.
+     *
+     * @return ApiResponse<UnreadNotificationStatusResponse> 형태로 안 읽은 알림 여부를 반환
+     */
     @GetMapping("/unread-status")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<UnreadNotificationStatusResponse> unreadNotificationsCheck() {
@@ -37,6 +53,13 @@ public class NotificationController {
         return ApiResponse.createSuccess(response);
     }
 
+    /**
+     * 특정 알림을 읽음으로 처리하는 API입니다.
+     * 해당 알림 ID를 받아 알림을 읽음 상태로 변경하고, 변경된 알림 정보를 반환합니다.
+     *
+     * @param notificationId 읽을 알림의 ID
+     * @return ApiResponse<NotificationResponse> 형태로 읽음 처리된 알림 정보를 반환
+     */
     @PatchMapping("/{notificationId}/read")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<NotificationResponse> notificationRead(

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/FriendNotificationResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/FriendNotificationResponse.java
@@ -1,0 +1,23 @@
+package com.example.favoriteschoolmeal.domain.notification.controller.dto;
+
+import com.example.favoriteschoolmeal.domain.notification.domain.FriendNotification;
+
+public record FriendNotificationResponse(
+        Long notificationId,
+        Long receiverId,
+        Long senderId,
+        Integer notificationType,
+        String createdAt,
+        Boolean isRead) implements NotificationResponse {
+
+    public static FriendNotificationResponse from(final FriendNotification notification) {
+        return new FriendNotificationResponse(
+                notification.getId(),
+                notification.getReceiver().getId(),
+                notification.getSenderId(),
+                notification.getNotificationType().getId(),
+                notification.getFormattedCreatedAt(),
+                notification.getIsRead()
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationListResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationListResponse.java
@@ -5,9 +5,9 @@ import java.util.List;
 public record NotificationListResponse(
         List<NotificationResponse> notificationList) {
 
-    public static NotificationListResponse from(final List<NotificationResponse> notificationList) {
+    public static NotificationListResponse from(final List<NotificationResponse> notifications) {
         return new NotificationListResponse(
-                notificationList
+                notifications
         );
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/NotificationResponse.java
@@ -1,25 +1,5 @@
 package com.example.favoriteschoolmeal.domain.notification.controller.dto;
 
-import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+public interface NotificationResponse {
 
-public record NotificationResponse(
-        Long notificationId,
-        Long postId,
-        Long receiverId,
-        Long senderId,
-        Integer notificationType,
-        String createdAt,
-        Boolean isRead) {
-
-    public static NotificationResponse from(final Notification notification) {
-        return new NotificationResponse(
-                notification.getId(),
-                notification.getPostId(),
-                notification.getReceiver().getId(),
-                notification.getSenderId(),
-                notification.getNotificationType().getId(),
-                notification.getFormattedCreatedAt(),
-                notification.getIsRead()
-        );
-    }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/PostNotificationResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/controller/dto/PostNotificationResponse.java
@@ -1,0 +1,25 @@
+package com.example.favoriteschoolmeal.domain.notification.controller.dto;
+
+import com.example.favoriteschoolmeal.domain.notification.domain.PostNotification;
+
+public record PostNotificationResponse(
+        Long notificationId,
+        Long postId,
+        Long receiverId,
+        Long senderId,
+        Integer notificationType,
+        String createdAt,
+        Boolean isRead) implements NotificationResponse {
+
+    public static PostNotificationResponse from(final PostNotification notification) {
+        return new PostNotificationResponse(
+                notification.getId(),
+                notification.getPostId(),
+                notification.getReceiver().getId(),
+                notification.getSenderId(),
+                notification.getNotificationType().getId(),
+                notification.getFormattedCreatedAt(),
+                notification.getIsRead()
+        );
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/FriendNotification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/FriendNotification.java
@@ -1,0 +1,24 @@
+package com.example.favoriteschoolmeal.domain.notification.domain;
+
+import com.example.favoriteschoolmeal.domain.member.domain.Member;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("FRIEND")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendNotification extends Notification {
+
+    @Builder
+    public FriendNotification(Member receiver, Long senderId, NotificationType notificationType,
+            Boolean isRead) {
+        super(receiver, senderId, notificationType);
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/Notification.java
@@ -4,6 +4,8 @@ import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.model.NotificationType;
 import com.example.favoriteschoolmeal.global.common.Base;
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -11,11 +13,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,9 +28,11 @@ import lombok.NoArgsConstructor;
  */
 @Entity
 @Table(name = "notification")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification extends Base {
+public abstract class Notification extends Base {
 
     /**
      * 알림의 고유 식별자입니다. 자동 생성되는 ID 값입니다.
@@ -50,12 +56,6 @@ public class Notification extends Base {
     private Long senderId;
 
     /**
-     * 알림과 관련된 게시물의 ID입니다.
-     */
-    @Column(name = "post_id", nullable = false)
-    private Long postId;
-
-    /**
      * 알림의 유형을 나타냅니다. NotificationType 열거형을 사용하여 알림의 유형을 정의합니다.
      */
     @Enumerated(EnumType.STRING)
@@ -66,26 +66,12 @@ public class Notification extends Base {
      * 알림의 읽음 여부를 나타냅니다. 기본값은 false(읽지 않음)입니다.
      */
     @Column(name = "is_read", nullable = false)
-    private Boolean isRead;
+    private Boolean isRead = false;
 
-    /**
-     * 알림 객체를 생성할 때 사용하는 빌더 메서드입니다.
-     *
-     * @param receiver         알림을 받는 사용자
-     * @param senderId         알림을 보낸 사용자의 ID
-     * @param postId           알림과 관련된 게시물 ID
-     * @param notificationType 알림의 유형
-     * @param isRead           알림의 읽음 여부
-     */
-    @Builder
-    public Notification(Member receiver, Long senderId, Long postId,
-            NotificationType notificationType,
-            Boolean isRead) {
+    protected Notification(Member receiver, Long senderId, NotificationType notificationType) {
         this.receiver = receiver;
         this.senderId = senderId;
-        this.postId = postId;
         this.notificationType = notificationType;
-        this.isRead = isRead;
     }
 
     /**

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/PostNotification.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/domain/PostNotification.java
@@ -1,0 +1,31 @@
+package com.example.favoriteschoolmeal.domain.notification.domain;
+
+import com.example.favoriteschoolmeal.domain.member.domain.Member;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("POST")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostNotification extends Notification {
+
+    /**
+     * 알림과 관련된 게시물의 ID입니다.
+     */
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Builder
+    public PostNotification(Member receiver, Long senderId, NotificationType notificationType,
+            Boolean isRead, Long postId) {
+        super(receiver, senderId, notificationType);
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/exception/NotificationExceptionType.java
@@ -21,6 +21,18 @@ public enum NotificationExceptionType implements BaseExceptionType {
             401,
             HttpStatus.UNAUTHORIZED,
             "Unauthorized access"
+    ),
+
+    UNSUPPORTED_NOTIFICATION_TYPE(
+            400,
+            HttpStatus.BAD_REQUEST,
+            "Unsupported notification type"
+    ),
+
+    INVALID_NOTIFICATION_TYPE(
+            400,
+            HttpStatus.BAD_REQUEST,
+            "Invalid notification type"
     );
 
     private final int errorCode;

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.example.favoriteschoolmeal.domain.notification.repository;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,12 +11,13 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     /**
-     * 특정 멤버의 모든 알림을 조회합니다.
+     * 특정 멤버의 모든 알림을 조회합니다. 추가된 Sort 매개변수를 통해 결과를 정렬할 수 있습니다.
      *
      * @param receiver 알림을 조회할 멤버 객체
-     * @return 주어진 멤버에 대한 알림 리스트
+     * @param sort 정렬 기준
+     * @return 주어진 멤버에 대한 정렬된 알림 리스트
      */
-    List<Notification> findAllByReceiver(Member receiver);
+    List<Notification> findAllByReceiver(Member receiver, Sort sort);
 
     /**
      * 멤버에게 안 읽은 알림이 있는지 여부를 확인합니다.

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
@@ -3,19 +3,29 @@ package com.example.favoriteschoolmeal.domain.notification.service;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.member.service.MemberService;
 import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.FriendNotificationResponse;
 import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationListResponse;
 import com.example.favoriteschoolmeal.domain.notification.controller.dto.NotificationResponse;
+import com.example.favoriteschoolmeal.domain.notification.controller.dto.PostNotificationResponse;
 import com.example.favoriteschoolmeal.domain.notification.controller.dto.UnreadNotificationStatusResponse;
+import com.example.favoriteschoolmeal.domain.notification.domain.FriendNotification;
 import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+import com.example.favoriteschoolmeal.domain.notification.domain.PostNotification;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationException;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationExceptionType;
 import com.example.favoriteschoolmeal.domain.notification.repository.NotificationRepository;
 import com.example.favoriteschoolmeal.global.security.util.SecurityUtils;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 알림 관련 서비스를 제공하는 클래스입니다.
+ * 이 서비스는 알림 생성, 조회 및 읽음 처리 등의 기능을 담당합니다.
+ */
 @Service
 @Transactional
 public class NotificationService {
@@ -29,31 +39,69 @@ public class NotificationService {
         this.memberService = memberService;
     }
 
-    public void createNotification(final Long senderId, final Long receiverId, final Long postId,
-            final NotificationType notificationType) {
-        Member member = getMemberOrThrow(receiverId);
-        Notification notification = Notification.builder()
+    /**
+     * 게시글 관련 알림을 생성합니다.
+     *
+     * @param senderId 알림 발신자 ID
+     * @param receiverId 알림 수신자 ID
+     * @param postId 관련 게시글 ID
+     * @param notificationType 알림 유형
+     */
+    public void createPostNotification(final Long senderId, final Long receiverId,
+            final Long postId, final NotificationType notificationType) {
+        validateNotificationType(notificationType, NotificationType::isPostRelated);
+        Member receiver = getMemberOrThrow(receiverId);
+        PostNotification notification = PostNotification.builder()
                 .senderId(senderId)
-                .receiver(member)
+                .receiver(receiver)
                 .postId(postId)
                 .notificationType(notificationType)
-                .isRead(false)
                 .build();
         notificationRepository.save(notification);
     }
 
+    /**
+     * 친구 관련 알림을 생성합니다.
+     *
+     * @param senderId 알림 발신자 ID
+     * @param receiverId 알림 수신자 ID
+     * @param notificationType 알림 유형
+     */
+    public void createFriendNotification(final Long senderId, final Long receiverId,
+            final NotificationType notificationType) {
+        validateNotificationType(notificationType, NotificationType::isFriendRelated);
+        Member receiver = getMemberOrThrow(receiverId);
+        FriendNotification notification = FriendNotification.builder()
+                .senderId(senderId)
+                .receiver(receiver)
+                .notificationType(notificationType)
+                .build();
+        notificationRepository.save(notification);
+    }
+
+    /**
+     * 사용자의 모든 알림을 조회합니다.
+     * 생성 시간 내림차순으로 정렬하여 반환합니다.
+     *
+     * @return NotificationListResponse 사용자의 모든 알림 목록
+     */
     @Transactional(readOnly = true)
     public NotificationListResponse findAllNotification() {
         verifyUserOrAdmin();
         Member receiver = getMemberOrThrow(getCurrentMemberId());
         List<NotificationResponse> notificationResponseList = notificationRepository
-                .findAllByReceiver(receiver)
+                .findAllByReceiver(receiver, Sort.by("createdAt").descending())
                 .stream()
-                .map(NotificationResponse::from)
+                .map(this::mapToNotificationResponse)
                 .collect(Collectors.toList());
         return NotificationListResponse.from(notificationResponseList);
     }
 
+    /**
+     * 사용자에게 안 읽은 알림이 있는지 확인합니다.
+     *
+     * @return UnreadNotificationStatusResponse 안 읽은 알림 여부
+     */
     @Transactional(readOnly = true)
     public UnreadNotificationStatusResponse hasUnreadNotifications() {
         verifyUserOrAdmin();
@@ -62,13 +110,36 @@ public class NotificationService {
                 notificationRepository.existsByReceiverAndIsRead(receiver, false));
     }
 
+    /**
+     * 특정 알림을 읽음으로 처리합니다.
+     *
+     * @param notificationId 읽을 알림의 ID
+     * @return NotificationResponse 읽음 처리된 알림의 정보
+     */
     public NotificationResponse readNotification(final Long notificationId) {
         verifyUserOrAdmin();
         Notification notification = getNotificationOrThrow(notificationId);
         verifyNotificationReceiver(notification, getCurrentMemberId());
         notification.readNotification();
         Notification savedNotification = notificationRepository.save(notification);
-        return NotificationResponse.from(savedNotification);
+        return mapToNotificationResponse(savedNotification);
+    }
+
+    private NotificationResponse mapToNotificationResponse(Notification notification) {
+        if (notification instanceof PostNotification) {
+            return PostNotificationResponse.from((PostNotification) notification);
+        }
+        if (notification instanceof FriendNotification) {
+            return FriendNotificationResponse.from((FriendNotification) notification);
+        }
+        throw new NotificationException(NotificationExceptionType.UNSUPPORTED_NOTIFICATION_TYPE);
+    }
+
+    private void validateNotificationType(NotificationType notificationType,
+            Predicate<NotificationType> validationPredicate) {
+        if (!validationPredicate.test(notificationType)) {
+            throw new NotificationException(NotificationExceptionType.INVALID_NOTIFICATION_TYPE);
+        }
     }
 
     private Notification getNotificationOrThrow(Long notificationId) {


### PR DESCRIPTION
## 📌 관련 이슈
closed #104

## 🛠️ 작업 내용
- [x] 알림 모델 수정
- [x] 알림 타입 수정
- [x] 알림 생성 로직 추가 및 분리
- [x] 알림 목록이 최근 순으로 반환되도록 수정

## 🎯 리뷰 포인트

친구 관련 기능 담당하신 분은 아래 내용과 작성된 자바독을 유념하셔서 알림 기능을 활용해주시길 바랍니다.

### 상세 리뷰 포인트: 알림 기능 확장 및 구현에 대한 상세 안내

#### 1. 알림 모델 수정 및 도메인 설계 고려사항

- **도메인 설계의 핵심 변경**: `Notification` 도메인에서 `postId` 필드는 게시물 관련 알림에만 적용됩니다. 친구 관련 기능에서는 `postId`가 불필요하기 때문에, 이를 고려한 도메인 모델의 수정이 필요했습니다.
- **상속 구조를 통한 모델 설계**: 공통 필드와 특수 필드를 명확하게 구분하기 위해 `Notification`을 추상 클래스로 정의하고, `PostNotification` 및 `FriendNotification`과 같은 구체 클래스를 통해 특화된 필드를 관리합니다. 이는 각 알림 유형의 특성을 반영하면서도 코드 중복을 최소화하는 방식입니다.
- **단일 테이블 전략 채택**: 프로젝트의 특성과 요구 사항을 고려하여 단일 테이블 전략을 채택했습니다. 이는 데이터베이스의 복잡성을 줄이고, 관리를 용이하게 합니다.

![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/66b8ef23-55e4-41ea-b831-3b5a1e91fed3)


#### 2. 알림 타입의 확장 및 관련 로직 처리

- **알림 타입의 다양화**: `NotificationType` 열거형에 친구 관련 알림 타입을 추가하여 알림의 범위를 확장했습니다. 
- **조건별 로직 처리**: 게시물과 친구 관련 알림을 구분하는 메소드(`isPostRelated`, `isFriendRelated`)를 통해 각각의 알림 유형에 맞는 로직을 처리할 수 있습니다.

#### 3. 알림 생성 로직의 개선

- **알림 생성 로직의 분리**: 게시물과 친구 관련 알림을 생성하는 로직을 분리함으로써, 각 기능의 독립성을 보장하고 유지보수를 용이하게 했습니다.
- **함수형 인터페이스 활용**: 가독성과 재사용성을 위해 `Predicate` 인터페이스를 사용하여 알림 유형의 유효성을 검증하는 메소드를 구현했습니다.

#### 4. 응답 클래스의 확장 및 분리

- **응답 클래스의 역할**: 각 알림 유형에 따른 응답 클래스(`PostNotificationResponse`, `FriendNotificationResponse`)는 알림의 세부 정보를 제공합니다.
- **인터페이스를 통한 일관성**: `NotificationResponse` 인터페이스를 통해 응답 클래스들이 일관된 형태를 유지하도록 했습니다. 

![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/ebed4745-fbe8-49d7-9e5c-afdb8be1ac39)

#### 5. 기타 변경 사항

- **최근 순 정렬**: 알림 목록 조회 시 최신 순으로 정렬되도록 구현했습니다. 

## ✅ 테스트 결과
기존 알림 기능 모두 정상적으로 동작함을 확인하였습니다. 현재 친구 관련 알람 기능이 완성되지 않아 게시물 관련 알람 기능을 테스트하였습니다.

- 알림 목록 조회

![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/95e46619-3e8f-4ab1-90bc-863e88f11d06)

