### PR TITLE
refactor: 친구 취소 시 MatchingMember를 삭제하는 것이 아닌, MatchingRequestStatus를 취소됨으로 변경

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
@@ -76,7 +76,7 @@ public class MatchingService {
         final Matching matching = getMatchingFromPost(post);
         final MatchingMember matchingMember = getMatchingMemberOrThrow(matching, applicant);
         verifyCancellation(matchingMember);
-        cancelMatchingMember(matchingMember);
+        updateMatchingMemberStatus(matchingMember, MatchingRequestStatus.CANCELED);
         notificationService.createPostNotification(applicant.getId(), post.getMember().getId(),
                 postId,
                 NotificationType.MATCHING_REQUEST_CANCELED);
@@ -214,10 +214,6 @@ public class MatchingService {
                 .matchingRequestStatus(MatchingRequestStatus.PENDING)
                 .build();
         matchingMemberRepository.save(matchingMember);
-    }
-
-    private void cancelMatchingMember(final MatchingMember matchingMember) {
-        matchingMemberRepository.delete(matchingMember);
     }
 
     private void updateMatchingMemberStatus(final MatchingMember matchingMember,

--- a/src/main/java/com/example/favoriteschoolmeal/domain/model/MatchingRequestStatus.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/model/MatchingRequestStatus.java
@@ -3,7 +3,8 @@ package com.example.favoriteschoolmeal.domain.model;
 public enum MatchingRequestStatus {
     PENDING("대기중"),
     ACCEPTED("승인됨"),
-    REJECTED("거절됨");
+    REJECTED("거절됨"),
+    CANCELED("취소됨");
 
     private final String description;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,12 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/fsm?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&useSSL=true
+    username: root
+    password: c2478256
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #131

## 🛠️ 작업 내용
- [x] MatchingRequestStatus에 취소 필드 추가
- [x] 매칭 취소 로직 수정

## 🎯 리뷰 포인트
@Yeomdonghwan 친구 요청 취소도 마찬가지로 수정해주세요

## ✅ 테스트 결과
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/cb19846c-ccaa-462c-b8b4-458b44e7c33a)

