### PR TITLE
feat: 친구/매칭 요청 알림 삭제

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/matching/service/MatchingService.java
@@ -76,6 +76,8 @@ public class MatchingService {
         final Matching matching = getMatchingFromPost(post);
         final MatchingMember matchingMember = getMatchingMemberOrThrow(matching, applicant);
         verifyCancellation(matchingMember);
+        notificationService.deleteByPostIdAndSenderIdAndNotificationType(postId, applicant.getId(),
+                NotificationType.MATCHING_REQUESTED);
         cancelMatchingMember(matchingMember);
         notificationService.createPostNotification(applicant.getId(), post.getMember().getId(),
                 postId,

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/FriendNotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/FriendNotificationRepository.java
@@ -1,0 +1,16 @@
+package com.example.favoriteschoolmeal.domain.notification.repository;
+
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.domain.FriendNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendNotificationRepository extends JpaRepository<FriendNotification, Long> {
+
+    /**
+     * 주어진 친구 ID와 알림 유형에 해당하는 친구 요청 관련 알림을 삭제합니다.
+     *
+     * @param friendId          삭제할 알림과 관련된 친구의 ID
+     * @param notificationType  삭제할 알림의 유형
+     */
+    void deleteByFriendIdAndNotificationType(Long friendId, NotificationType notificationType);
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -30,20 +30,4 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
      * @return 안 읽은 알림 존재 여부
      */
     boolean existsByReceiverAndIsRead(Member receiver, boolean isRead);
-
-    /**
-     * 주어진 친구 ID와 알림 유형에 해당하는 친구 요청 관련 알림을 삭제합니다.
-     *
-     * @param friendId          삭제할 알림과 관련된 친구의 ID
-     * @param notificationType  삭제할 알림의 유형
-     */
-    void deleteByFriendIdAndNotificationType(Long friendId, NotificationType notificationType);
-
-    /**
-     * 주어진 게시물 ID와 알림 유형에 해당하는 매칭 요청 관련 알림을 삭제합니다.
-     *
-     * @param postId            삭제할 알림과 관련된 게시물의 ID
-     * @param notificationType  삭제할 알림의 유형
-     */
-    void deleteByPostIdAndNotificationType(Long postId, NotificationType notificationType);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,10 @@
 package com.example.favoriteschoolmeal.domain.notification.repository;
 
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.domain.FriendNotification;
 import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
+import com.example.favoriteschoolmeal.domain.notification.domain.PostNotification;
 import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +30,20 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
      * @return 안 읽은 알림 존재 여부
      */
     boolean existsByReceiverAndIsRead(Member receiver, boolean isRead);
+
+    /**
+     * 주어진 친구 ID와 알림 유형에 해당하는 친구 요청 관련 알림을 삭제합니다.
+     *
+     * @param friendId          삭제할 알림과 관련된 친구의 ID
+     * @param notificationType  삭제할 알림의 유형
+     */
+    void deleteByFriendIdAndNotificationType(Long friendId, NotificationType notificationType);
+
+    /**
+     * 주어진 게시물 ID와 알림 유형에 해당하는 매칭 요청 관련 알림을 삭제합니다.
+     *
+     * @param postId            삭제할 알림과 관련된 게시물의 ID
+     * @param notificationType  삭제할 알림의 유형
+     */
+    void deleteByPostIdAndNotificationType(Long postId, NotificationType notificationType);
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/PostNotificationRepository.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/repository/PostNotificationRepository.java
@@ -1,0 +1,27 @@
+package com.example.favoriteschoolmeal.domain.notification.repository;
+
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.domain.PostNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostNotificationRepository extends JpaRepository<PostNotification, Long> {
+
+    /**
+     * 주어진 게시물 ID와 알림 유형에 해당하는 매칭 요청 관련 알림을 삭제합니다.
+     * 이 메서드는 게시물이 삭제될 때 관련된 매칭 요청 알림을 청소하는 데 사용됩니다.
+     *
+     * @param postId           삭제할 알림과 관련된 게시물의 ID
+     * @param notificationType 삭제할 알림의 유형
+     */
+    void deleteByPostIdAndNotificationType(Long postId, NotificationType notificationType);
+
+    /**
+     * 주어진 게시물 ID, 수신자 ID, 알림 유형에 해당하는 매칭 요청 관련 알림을 삭제합니다.
+     * 이 메서드는 매칭 요청을 취소할 때 관련된 매칭 요청 알림을 청소하는 데 사용됩니다.
+     *
+     * @param postId           삭제할 알림과 관련된 게시물의 ID
+     * @param senderId       삭제할 알림의 발신자 ID
+     * @param notificationType 삭제할 알림의 유형
+     */
+    void deleteByPostIdAndSenderIdAndNotificationType(Long postId, Long senderId, NotificationType notificationType);
+}

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
@@ -114,6 +114,30 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    /**
+     * 주어진 친구 ID에 해당하는 친구 요청 관련 알림을 삭제합니다.
+     * 이 메소드는 사용자가 친구 요청을 처리한 후 관련 알림을 청소하는 데 사용됩니다.
+     *
+     * @param friendId 삭제할 알림과 관련된 친구의 ID
+     */
+    public void deleteFriendRequestNotifications(Long friendId) {
+        notificationRepository.deleteByFriendIdAndNotificationType(
+                friendId, NotificationType.FRIEND_REQUESTED
+        );
+    }
+
+    /**
+     * 주어진 게시물 ID에 해당하는 매칭 요청 관련 알림을 삭제합니다.
+     * 이 메소드는 사용자가 매칭 요청을 처리한 후 관련 알림을 청소하는 데 사용됩니다.
+     *
+     * @param postId 삭제할 알림과 관련된 게시물의 ID
+     */
+    public void deleteMatchingRequestNotifications(Long postId) {
+        notificationRepository.deleteByPostIdAndNotificationType(
+                postId, NotificationType.MATCHING_REQUESTED
+        );
+    }
+
     private void validateNotificationType(NotificationType notificationType,
             Predicate<NotificationType> validationPredicate) {
         if (!validationPredicate.test(notificationType)) {

--- a/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/notification/service/NotificationService.java
@@ -9,10 +9,13 @@ import com.example.favoriteschoolmeal.domain.notification.domain.Notification;
 import com.example.favoriteschoolmeal.domain.notification.domain.PostNotification;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationException;
 import com.example.favoriteschoolmeal.domain.notification.exception.NotificationExceptionType;
+import com.example.favoriteschoolmeal.domain.notification.repository.FriendNotificationRepository;
 import com.example.favoriteschoolmeal.domain.notification.repository.NotificationRepository;
+import com.example.favoriteschoolmeal.domain.notification.repository.PostNotificationRepository;
 import com.example.favoriteschoolmeal.global.security.util.SecurityUtils;
 import java.util.List;
 import java.util.function.Predicate;
+import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,16 +25,13 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @Transactional
+@AllArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final PostNotificationRepository postNotificationRepository;
+    private final FriendNotificationRepository friendNotificationRepository;
     private final MemberService memberService;
-
-    public NotificationService(final NotificationRepository notificationRepository,
-            final MemberService memberService) {
-        this.notificationRepository = notificationRepository;
-        this.memberService = memberService;
-    }
 
     /**
      * 게시글 관련 알림을 생성합니다.
@@ -115,27 +115,40 @@ public class NotificationService {
     }
 
     /**
-     * 주어진 친구 ID에 해당하는 친구 요청 관련 알림을 삭제합니다.
-     * 이 메소드는 사용자가 친구 요청을 처리한 후 관련 알림을 청소하는 데 사용됩니다.
+     * 주어진 친구 ID에 해당하는 친구 요청 관련 알림을 삭제합니다. 이 메서드는 사용자가 친구 요청을 처리한 후 관련 알림을 청소하는 데 사용됩니다.
      *
      * @param friendId 삭제할 알림과 관련된 친구의 ID
      */
-    public void deleteFriendRequestNotifications(Long friendId) {
-        notificationRepository.deleteByFriendIdAndNotificationType(
-                friendId, NotificationType.FRIEND_REQUESTED
+    public void deleteByFriendIdAndNotificationType(Long friendId,
+            NotificationType notificationType) {
+        friendNotificationRepository.deleteByFriendIdAndNotificationType(
+                friendId, notificationType
         );
     }
 
     /**
-     * 주어진 게시물 ID에 해당하는 매칭 요청 관련 알림을 삭제합니다.
-     * 이 메소드는 사용자가 매칭 요청을 처리한 후 관련 알림을 청소하는 데 사용됩니다.
+     * 주어진 게시물 ID에 해당하는 매칭 요청 관련 알림을 삭제합니다. 이 메서드는 게시물이 삭제될 때 관련된 매칭 요청 알림을 청소하는 데 사용됩니다.
      *
      * @param postId 삭제할 알림과 관련된 게시물의 ID
      */
-    public void deleteMatchingRequestNotifications(Long postId) {
-        notificationRepository.deleteByPostIdAndNotificationType(
-                postId, NotificationType.MATCHING_REQUESTED
+    public void deleteByPostIdAndNotificationType(Long postId, NotificationType notificationType) {
+        postNotificationRepository.deleteByPostIdAndNotificationType(
+                postId, notificationType
         );
+    }
+
+    /**
+     * 주어진 게시물 ID, 수신자 ID, 알림 유형에 해당하는 매칭 요청 관련 알림을 삭제합니다. 이 메서드는 매칭 요청을 취소할 때 관련된 매칭 요청 알림을 청소하는 데
+     * 사용됩니다.
+     *
+     * @param postId           삭제할 알림과 관련된 게시물의 ID
+     * @param senderId         삭제할 알림의 발신자 ID
+     * @param notificationType 삭제할 알림의 유형
+     */
+    public void deleteByPostIdAndSenderIdAndNotificationType(Long postId, Long senderId,
+            NotificationType notificationType) {
+        postNotificationRepository.deleteByPostIdAndSenderIdAndNotificationType(postId, senderId,
+                notificationType);
     }
 
     private void validateNotificationType(NotificationType notificationType,

--- a/src/main/java/com/example/favoriteschoolmeal/domain/post/service/PostService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/post/service/PostService.java
@@ -7,6 +7,8 @@ import com.example.favoriteschoolmeal.domain.matching.domain.Matching;
 import com.example.favoriteschoolmeal.domain.matching.service.MatchingService;
 import com.example.favoriteschoolmeal.domain.member.domain.Member;
 import com.example.favoriteschoolmeal.domain.member.service.MemberService;
+import com.example.favoriteschoolmeal.domain.model.NotificationType;
+import com.example.favoriteschoolmeal.domain.notification.service.NotificationService;
 import com.example.favoriteschoolmeal.domain.post.controller.dto.CreatePostRequest;
 import com.example.favoriteschoolmeal.domain.post.controller.dto.PaginatedPostListResponse;
 import com.example.favoriteschoolmeal.domain.post.controller.dto.PostDetailResponse;
@@ -39,6 +41,7 @@ public class PostService {
     private final MatchingService matchingService;
     private final RestaurantService restaurantService;
     private final CommentService commentService;
+    private final NotificationService notificationService;
 
     public PostDetailResponse addPost(final CreatePostRequest request, final Long restaurantId) {
         verifyUserOrAdmin();
@@ -117,6 +120,8 @@ public class PostService {
         verifyUserOrAdmin();
         final Post post = getPostOrThrow(postId);
         verifyPostOwnerOrAdmin(post.getMember().getId(), getCurrentMemberId());
+        notificationService.deleteByPostIdAndNotificationType(postId,
+                NotificationType.MATCHING_REQUESTED);
         removeRelatedEntities(post);
         postRepository.delete(post);
     }


### PR DESCRIPTION
## 📌 관련 이슈
closed #133

## 🛠️ 작업 내용
-> 친구 삭제 및 친구 신청 취소: 삭제/신청 취소 알림을 생성한다. 해당 friendId를 가지고 NotificationType이 친구 요청인 알림을 삭제한다. 그 후 친구를 삭제한다.
-> 게시물 삭제: 해당 postId를 가지고 NotificationType이 매칭 요청인 알림을 삭제한다. 이때 게시물을 삭제하면 매칭 멤버도 함께 사라지므로 별도로 삭제할 것은 없다.
-> 매칭 신청 취소: 신청 취소 알림을 생성한다. 해당 postId를 가지고 receiverId가 현재 멤버이고 NotificationType이 매칭 요청인 알림을 삭제한다. 매칭 멤버를 삭제한다.


## 🎯 리뷰 포인트


## ✅ 테스트 결과
![image](https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/96174711/fa3ee5fc-c134-47a0-abfe-0d0dbc5ac1bb)
