### PR TITLE
feat: 기본 프로필 이미지 설정 

### DIFF
--- a/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/file/service/FileService.java
@@ -7,6 +7,8 @@ import com.example.favoriteschoolmeal.domain.file.repository.FileRepository;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +25,13 @@ import org.springframework.web.multipart.MultipartFile;
 public class FileService {
 
     private final FileRepository fileRepository;
+
     // 이미지를 불러올 때 사용할 경로
     private final String viewPath = "/images/";
+
+    //허용되는 확장자 목록
+    private final List<String> ALLOWED_EXTENSIONS = Arrays.asList(".jpg", ".jpeg", ".png");
+
     @Value("${file.dir}")
     private String fileDir;
 
@@ -104,9 +111,9 @@ public class FileService {
     }
 
     private String getExtensionOrThrow(String origName) {
-        // 확장자 추출(ex : .jpg) 현재 jpg만 허용
         String extension = origName.substring(origName.lastIndexOf("."));
-        if (!extension.equalsIgnoreCase(".jpg")) {
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
             throw new FileException(FileExceptionType.UNSUPPORTED_EXTENSION);
         }
         return extension;

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
@@ -18,6 +18,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,6 +30,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends Base {
+
+    private final String DEFAULT_PROFILE_IMAGE_ENDPOINT = "/images/default_profile_image.png";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -122,6 +125,11 @@ public class Member extends Base {
 
     public void modifyPassword(final String password) {
         this.password = password;
+    }
+
+    public String getProfileImageEndpoint() {
+        Optional<FileEntity> profileImage = Optional.ofNullable(this.profileImage);
+        return profileImage.map(FileEntity::getEndpoint).orElse(DEFAULT_PROFILE_IMAGE_ENDPOINT);
     }
 
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/domain/Member.java
@@ -31,7 +31,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends Base {
 
-    private final String DEFAULT_PROFILE_IMAGE_ENDPOINT = "/images/default_profile_image.png";
+    // 기본 프로필 이미지 엔드포인트
+    private final transient String DEFAULT_PROFILE_IMAGE_ENDPOINT = "/images/default_profile_image.png";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberDetailResponse.java
@@ -30,9 +30,7 @@ public record MemberDetailResponse(
                 member.getAge(),
                 member.getGender(),
                 member.getIntroduction(),
-                Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getEndpoint)
-                        .orElse(null)
+                member.getProfileImageEndpoint()
         );
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSimpleResponse.java
@@ -17,8 +17,6 @@ public record MemberSimpleResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getUsername(),
-                Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getEndpoint)
-                        .orElse(null));
+                member.getProfileImageEndpoint());
     }
 }

--- a/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
+++ b/src/main/java/com/example/favoriteschoolmeal/domain/member/dto/MemberSummaryResponse.java
@@ -34,9 +34,7 @@ public record MemberSummaryResponse(
                 member.getAge(),
                 member.getGender(),
                 member.getIntroduction(),
-                Optional.ofNullable(member.getProfileImage())
-                        .map(FileEntity::getEndpoint)
-                        .orElse(null)
+                member.getProfileImageEndpoint()
         );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

closed #135 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [ ] member객체의 profileImage가 null인 경우 기본 프로필 이미지의 엔드포인트를 반환하도록 추가
- [ ] 프로필 이미지 업로드시 .jpg, .jpeg, .png 확장자를 허용하도록 추가

## 🎯 리뷰 포인트
member엔티티 내 DEFAULT_PROFILE_IMAGE_ENDPOINT는 기본 프로필 이미지 엔드포인트를 저장하는 상수입니다. transient 키워드를 사용하여 컬럼으로 추가되지 않도록 설정했습니다.


## ✅ 테스트 결과

<img width="679" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/2280df0e-7644-447c-bcab-f6d2f40e087e">
프로필 업로드시

<img width="695" alt="image" src="https://github.com/Favorite-School-Meal/favorite-school-meal-was/assets/101257697/33a85733-40cb-4799-83c1-37fabbd63a7d">
프로필 이미지가 없는 회원의 정보 조회시 기본 프로필이미지 엔드포인트 제공
